### PR TITLE
Refactor: Remove redundant canAvoidRoom property

### DIFF
--- a/app/src/main/java/dev/mattbachmann/scoundroid/data/model/GameState.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/data/model/GameState.kt
@@ -8,7 +8,6 @@ package dev.mattbachmann.scoundroid.data.model
  * @property currentRoom The cards currently in the room (4 cards when drawn, 1 after selection)
  * @property equippedWeapon The currently equipped weapon card, if any
  * @property discardPile Cards that have been discarded
- * @property canAvoidRoom Whether the player can avoid the current/next room
  * @property lastRoomAvoided Whether the last room was avoided (for tracking consecutive avoidance)
  */
 data class GameState(
@@ -17,7 +16,6 @@ data class GameState(
     val currentRoom: List<Card>?,
     val equippedWeapon: Card?,
     val discardPile: List<Card>,
-    val canAvoidRoom: Boolean,
     val lastRoomAvoided: Boolean,
 ) {
     companion object {
@@ -35,7 +33,6 @@ data class GameState(
                 currentRoom = null,
                 equippedWeapon = null,
                 discardPile = emptyList(),
-                canAvoidRoom = true,
                 lastRoomAvoided = false,
             )
         }
@@ -59,14 +56,13 @@ data class GameState(
         return copy(
             deck = remainingDeck,
             currentRoom = newRoom,
-            canAvoidRoom = true,
             lastRoomAvoided = if (currentRoom != null) false else lastRoomAvoided,
         )
     }
 
     /**
      * Avoids the current room, moving all cards to the bottom of the deck.
-     * Can only be done if canAvoidRoom is true.
+     * Cannot be done if the last room was also avoided.
      */
     fun avoidRoom(): GameState {
         require(currentRoom != null) { "No room to avoid" }
@@ -79,7 +75,6 @@ data class GameState(
         return copy(
             deck = newDeck,
             currentRoom = null,
-            canAvoidRoom = false,
             lastRoomAvoided = true,
         )
     }

--- a/app/src/test/java/dev/mattbachmann/scoundroid/data/model/GameStateTest.kt
+++ b/app/src/test/java/dev/mattbachmann/scoundroid/data/model/GameStateTest.kt
@@ -32,12 +32,6 @@ class GameStateTest {
     }
 
     @Test
-    fun `new game should allow room avoidance`() {
-        val gameState = GameState.newGame()
-        assertTrue(gameState.canAvoidRoom)
-    }
-
-    @Test
     fun `drawing room should create room with 4 cards`() {
         val gameState = GameState.newGame()
         val newState = gameState.drawRoom()
@@ -62,7 +56,6 @@ class GameStateTest {
                 currentRoom = null,
                 equippedWeapon = null,
                 discardPile = emptyList(),
-                canAvoidRoom = true,
                 lastRoomAvoided = false,
             )
         val newState = gameState.drawRoom()
@@ -87,14 +80,6 @@ class GameStateTest {
     }
 
     @Test
-    fun `avoiding room should set canAvoidRoom to false`() {
-        val gameState = GameState.newGame().drawRoom()
-        val newState = gameState.avoidRoom()
-
-        assertFalse(newState.canAvoidRoom)
-    }
-
-    @Test
     fun `avoiding room should set lastRoomAvoided to true`() {
         val gameState = GameState.newGame().drawRoom()
         val newState = gameState.avoidRoom()
@@ -109,19 +94,19 @@ class GameStateTest {
                 .drawRoom()
                 .avoidRoom()
 
-        assertFalse(gameState.canAvoidRoom)
+        assertTrue(gameState.lastRoomAvoided)
     }
 
     @Test
     fun `processing room should restore room avoidance ability`() {
-        val gameState =
-            GameState.newGame()
-                .drawRoom()
-                .avoidRoom()
-                .drawRoom()
+        val state1 = GameState.newGame().drawRoom()
+        val state2 = state1.avoidRoom()
+        val state3 = state2.drawRoom()
+        val state4 = state3.selectCards(state3.currentRoom!!.take(3))
+        val gameState = state4.drawRoom()
 
-        // After drawing a new room (which means we didn't avoid), we should be able to avoid again
-        assertTrue(gameState.canAvoidRoom)
+        // After avoiding a room, then processing the next room, we should be able to avoid again
+        assertFalse(gameState.lastRoomAvoided)
     }
 
     @Test
@@ -202,7 +187,6 @@ class GameStateTest {
                 currentRoom = null,
                 equippedWeapon = null,
                 discardPile = emptyList(),
-                canAvoidRoom = true,
                 lastRoomAvoided = false,
             )
 


### PR DESCRIPTION
## Summary
- Remove redundant `canAvoidRoom` property from `GameState`
- Simplify room avoidance logic to use only `lastRoomAvoided`
- Update all tests to reflect the simplified state model

## Details

The `canAvoidRoom` property was redundant after commit 11ac6d1. All game logic enforcement was actually handled by `lastRoomAvoided`. The `canAvoidRoom` property was always set to `true` in `drawRoom()` and `false` in `avoidRoom()`, but never actually checked for game logic decisions.

This refactoring:
- Removes the unused property entirely
- Updates documentation to reflect actual behavior
- Fixes one test that wasn't properly testing room processing behavior
- Maintains all existing functionality with cleaner code

## Test plan
- [x] All 56 unit tests passing
- [x] Room avoidance rules still enforced correctly (cannot avoid twice in a row)
- [x] Room processing correctly resets avoidance ability

🤖 Generated with [Claude Code](https://claude.com/claude-code)