### PR TITLE
Update Java version from 11 to 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,11 +29,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
## Summary
- Update Java source and target compatibility from 11 to 17
- Update Kotlin JVM target to match (17)

## Details

This updates the project's Java version configuration in the Gradle build file to use Java 17, which is a more modern LTS version with better performance and features.

## Test plan
- [ ] Project builds successfully with Java 17
- [ ] All tests pass with the updated configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)