### PR TITLE
Address additional PR #7 review feedback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,6 @@ max_line_length = 120
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
 # Allow PascalCase for Composable functions
-ktlint_function_naming = disabled
 ktlint_standard_function-naming = disabled
 # Allow inline comments in argument lists
 ktlint_standard_comment-wrapping = disabled

--- a/app/src/main/java/dev/mattbachmann/scoundroid/data/model/GameState.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/data/model/GameState.kt
@@ -211,13 +211,6 @@ data class GameState(
     }
 
     /**
-     * Clears the current room (after processing the last card).
-     */
-    fun clearRoom(): GameState {
-        return copy(currentRoom = null)
-    }
-
-    /**
      * Calculates the current score.
      *
      * Scoring rules:

--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/CardView.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/CardView.kt
@@ -79,9 +79,8 @@ fun CardView(
             Suit.HEARTS -> "Hearts"
         }
     val selectedText = if (isSelected) ", selected" else ""
-    val clickableText = if (onClick != null) ". Click to select" else ""
     val accessibilityDescription =
-        "$typeName card, ${card.rank.displayName} of $suitName, value ${card.value}$selectedText$clickableText"
+        "$typeName card, ${card.rank.displayName} of $suitName, value ${card.value}$selectedText"
 
     val actualBorderWidth = if (isSelected) 4.dp else 2.dp
     val actualBorderColor = if (isSelected) Color(0xFFFFD700) else borderColor

--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/RoomDisplay.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/RoomDisplay.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,7 +26,7 @@ import dev.mattbachmann.scoundroid.ui.theme.ScoundroidTheme
 fun RoomDisplay(
     cards: List<Card>,
     selectedCards: Set<Card>,
-    onCardClick: (Card) -> Unit,
+    onCardClick: ((Card) -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -53,32 +54,32 @@ fun RoomDisplay(
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
                 ) {
                     CardView(
                         card = cards[0],
                         isSelected = cards[0] in selectedCards,
-                        onClick = { onCardClick(cards[0]) },
+                        onClick = onCardClick?.let { { it(cards[0]) } },
                     )
                     CardView(
                         card = cards[1],
                         isSelected = cards[1] in selectedCards,
-                        onClick = { onCardClick(cards[1]) },
+                        onClick = onCardClick?.let { { it(cards[1]) } },
                     )
                 }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
                 ) {
                     CardView(
                         card = cards[2],
                         isSelected = cards[2] in selectedCards,
-                        onClick = { onCardClick(cards[2]) },
+                        onClick = onCardClick?.let { { it(cards[2]) } },
                     )
                     CardView(
                         card = cards[3],
                         isSelected = cards[3] in selectedCards,
-                        onClick = { onCardClick(cards[3]) },
+                        onClick = onCardClick?.let { { it(cards[3]) } },
                     )
                 }
             }
@@ -86,13 +87,13 @@ fun RoomDisplay(
             // Single card or other layouts
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
             ) {
                 cards.forEach { card ->
                     CardView(
                         card = card,
                         isSelected = card in selectedCards,
-                        onClick = { onCardClick(card) },
+                        onClick = onCardClick?.let { { it(card) } },
                     )
                 }
             }

--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameIntent.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameIntent.kt
@@ -23,19 +23,9 @@ sealed class GameIntent {
     data object AvoidRoom : GameIntent()
 
     /**
-     * Select 3 of the 4 cards in the room to process.
-     * @param selectedCards The 3 cards chosen from the room
+     * Select and process 3 cards from the room.
+     * This combines selection and processing into a single atomic operation.
+     * @param selectedCards The 3 cards chosen from the room to process
      */
-    data class SelectCards(val selectedCards: List<Card>) : GameIntent()
-
-    /**
-     * Process a single card (monster, weapon, or potion).
-     * @param card The card to process
-     */
-    data class ProcessCard(val card: Card) : GameIntent()
-
-    /**
-     * Clear the current room (after processing the last card).
-     */
-    data object ClearRoom : GameIntent()
+    data class ProcessSelectedCards(val selectedCards: List<Card>) : GameIntent()
 }

--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
@@ -92,21 +92,21 @@ fun GameScreen(
                 )
             } else {
                 // Active game
-                if (uiState.currentRoom != null) {
+                val currentRoom = uiState.currentRoom
+                if (currentRoom != null) {
                     // Show current room
-                    if (uiState.currentRoom!!.size == 1) {
+                    if (currentRoom.size == 1) {
                         // Single card remaining - show it but don't allow clicking
                         // This card becomes part of the next room
-                        // No action - can't process the leftover card
                         RoomDisplay(
-                            cards = uiState.currentRoom!!,
+                            cards = currentRoom,
                             selectedCards = emptySet(),
-                            onCardClick = { },
+                            onCardClick = null,
                         )
                     } else {
                         // Room of 4 - allow selection
                         RoomDisplay(
-                            cards = uiState.currentRoom!!,
+                            cards = currentRoom,
                             selectedCards = selectedCards,
                             onCardClick = { card ->
                                 selectedCards =
@@ -122,7 +122,7 @@ fun GameScreen(
                     }
 
                     // Room actions
-                    if (uiState.currentRoom!!.size == 4) {
+                    if (currentRoom.size == 4) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -143,11 +143,9 @@ fun GameScreen(
                             // Process selected cards button
                             Button(
                                 onClick = {
-                                    viewModel.onIntent(GameIntent.SelectCards(selectedCards.toList()))
-                                    // Process each selected card
-                                    selectedCards.forEach { card ->
-                                        viewModel.onIntent(GameIntent.ProcessCard(card))
-                                    }
+                                    viewModel.onIntent(
+                                        GameIntent.ProcessSelectedCards(selectedCards.toList()),
+                                    )
                                     selectedCards = emptySet()
                                 },
                                 enabled = selectedCards.size == 3,
@@ -161,7 +159,7 @@ fun GameScreen(
                                 Text("Process ${selectedCards.size}/3 Cards")
                             }
                         }
-                    } else if (uiState.currentRoom!!.size == 1) {
+                    } else if (currentRoom.size == 1) {
                         // 1 card remaining - show Draw Room button to continue
                         Text(
                             text = "This card stays for the next room",


### PR DESCRIPTION
- Remove !! operators in GameScreen by extracting currentRoom to local variable
- Remove unused ClearRoom intent and clearRoom method (dead code)
- Combine SelectCards/ProcessCard intents into single ProcessSelectedCards
- Fix accessibility text: remove "Click to select" for non-interactive cards
- Remove duplicate ktlint rule from .editorconfig
- Clarify potion test name to explain room processing sequence behavior
- Add horizontal spacing (12dp) between cards in RoomDisplay
- Update tests to use new ProcessSelectedCards intent pattern