### PR TITLE
Increase icon size in unfolded mode for better visibility

### DIFF
--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -131,6 +132,7 @@ fun GameScreen(
                                     imageVector = Icons.AutoMirrored.Filled.List,
                                     contentDescription = "Action Log",
                                     tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(32.dp),
                                 )
                             }
                             IconButton(onClick = { viewModel.onIntent(GameIntent.ShowHelp) }) {
@@ -138,6 +140,7 @@ fun GameScreen(
                                     imageVector = Icons.AutoMirrored.Filled.Help,
                                     contentDescription = "Help",
                                     tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(32.dp),
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- Increased help and action log icons from default 24dp to 32dp in expanded (unfolded) layout
- Improves touch targets and visibility on the larger unfolded display

## Test plan
- [ ] Open app in unfolded mode on Pixel 10 Pro Fold
- [ ] Verify help and action log icons are larger and easier to tap
- [ ] Verify icons still look appropriate in folded mode (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)