### PR TITLE
Fix primary button text contrast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,10 @@ dev.mattbachmann.scoundroid/
 
 ## Development Guidelines
 
+### Build Verification
+- Always run `./gradlew build` to verify changes (runs compilation, linting, and tests)
+- Do not use `./gradlew assembleDebug` as it skips tests
+
 ### Code Style
 - Use Kotlin idioms (data classes, sealed classes, extension functions)
 - Prefer immutability (val over var, immutable collections)

--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -298,6 +299,7 @@ private fun RoomActionButtons(
     val primaryButtonColors =
         ButtonDefaults.buttonColors(
             containerColor = ButtonPrimary,
+            contentColor = Color.White,
         )
     val primaryButtonElevation =
         ButtonDefaults.buttonElevation(
@@ -715,7 +717,7 @@ private fun GameOverScreen(
 
         if (showButton) {
             val buttonShape = remember { RoundedCornerShape(12.dp) }
-            val buttonColors = ButtonDefaults.buttonColors(containerColor = ButtonPrimary)
+            val buttonColors = ButtonDefaults.buttonColors(containerColor = ButtonPrimary, contentColor = Color.White)
             val buttonElevation =
                 ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 8.dp)
             Button(
@@ -779,7 +781,7 @@ private fun GameWonScreen(
 
         if (showButton) {
             val buttonShape = remember { RoundedCornerShape(12.dp) }
-            val buttonColors = ButtonDefaults.buttonColors(containerColor = ButtonPrimary)
+            val buttonColors = ButtonDefaults.buttonColors(containerColor = ButtonPrimary, contentColor = Color.White)
             val buttonElevation =
                 ButtonDefaults.buttonElevation(defaultElevation = 4.dp, pressedElevation = 8.dp)
             Button(


### PR DESCRIPTION
## Summary
- Add explicit white `contentColor` to primary buttons for better readability against the purple `ButtonPrimary` background
- Add build verification guidelines to CLAUDE.md recommending `./gradlew build` over `assembleDebug`

## Test plan
- [x] Launch app and verify "Draw Room" button text is white and readable
- [x] Verify "New Game" button text after game over/victory is also white
- [x] Run `./gradlew build` to confirm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)