### PR TITLE
Add physical deck play tips to in-app help

### DIFF
--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/HelpContent.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/HelpContent.kt
@@ -89,6 +89,22 @@ fun HelpContent(modifier: Modifier = Modifier) {
                 """.trimIndent(),
         )
 
+        HelpSection(
+            title = "Playing with Real Cards",
+            content =
+                """
+                Setup: Remove all Jokers, red face cards (J/Q/K of Hearts and Diamonds), and red Aces. You should have 44 cards.
+
+                Track health: Use a d20 die, paper, or 20 tokens (remove as you take damage).
+
+                Track weapon degradation: Keep the last defeated monster under your weapon as a reminder of its limit.
+
+                Room layout: Draw 4 cards in a row. When leaving one behind, slide it left and draw 3 more for the next room.
+
+                Skip tracking: Use a coin—heads means you can skip, tails means you must play. Flip after each room.
+                """.trimIndent(),
+        )
+
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(


### PR DESCRIPTION
## Summary
- Adds a "Playing with Real Cards" section to the in-app help content
- Covers deck setup, health tracking methods, weapon degradation tracking, room layout, and skip status tracking
- Helps players who want to try Scoundrel with an actual deck of cards

## Test plan
- [ ] Open the app and navigate to the help/rules screen
- [ ] Scroll to the bottom and verify the new "Playing with Real Cards" section appears
- [ ] Verify all tips are readable and make sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)