### PR TITLE
Add privacy policy for Play Store submission

### DIFF
--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,0 +1,42 @@
+# Privacy Policy for Scoundroid
+
+**Last updated:** January 2025
+
+## Overview
+
+Scoundroid is a single-player card game based on "Scoundrel" by Zach Gage and Kurt Bieg. This privacy policy explains how the app handles your information.
+
+## Data Collection
+
+**Scoundroid does not collect, store, or transmit any personal data.**
+
+Specifically, the app:
+- Does not require an internet connection
+- Does not collect personal information
+- Does not use analytics or tracking
+- Does not contain advertisements
+- Does not share any data with third parties
+
+## Local Storage
+
+The app stores game state and high scores locally on your device. This data:
+- Never leaves your device
+- Is not accessible to the developer or any third party
+- Can be deleted by uninstalling the app or clearing app data
+
+## Children's Privacy
+
+Scoundroid does not collect any personal information from anyone, including children under 13.
+
+## Changes to This Policy
+
+If this privacy policy changes, the updated version will be posted here with a new "Last updated" date.
+
+## Contact
+
+If you have questions about this privacy policy, you can reach the developer at:
+- GitHub: https://github.com/Bachmann1234
+
+## Attribution
+
+Scoundroid is a fan implementation of "Scoundrel," the original card game designed by Zach Gage and Kurt Bieg. Learn more about the original game at http://www.stfj.net/scoundrel/


### PR DESCRIPTION
## Summary
- Adds privacy policy document required for Google Play Store submission
- Documents that the app collects no personal data
- Includes attribution to original Scoundrel game creators

## Notes
The privacy policy will need to be hosted at a URL for the Play Store listing. Options:
- Use the GitHub raw URL directly
- Enable GitHub Pages
- Host elsewhere

## Test plan
- [x] Verify privacy policy content is accurate
- [x] Confirm attribution is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)