### PR TITLE
Show disabled Process Cards button with visible styling

### DIFF
--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/screen/game/GameScreen.kt
@@ -340,6 +340,8 @@ private fun RoomActionButtons(
         ButtonDefaults.buttonColors(
             containerColor = ButtonPrimary,
             contentColor = Color.White,
+            disabledContainerColor = ButtonPrimary.copy(alpha = 0.5f),
+            disabledContentColor = Color.White.copy(alpha = 0.7f),
         )
     val primaryButtonElevation =
         ButtonDefaults.buttonElevation(


### PR DESCRIPTION
## Summary
- Add explicit disabled colors to the Process Cards button
- Button now shows at 50% opacity when fewer than 3 cards are selected
- Provides visual feedback that the action exists but requires more card selections

## Test plan
- [ ] Launch app and draw a room with 4 cards
- [ ] Verify "Process 0/3 Cards" button is visible (semi-transparent) next to "Avoid Room"
- [ ] Select 1-2 cards and verify button updates text but remains disabled
- [ ] Select 3 cards and verify button becomes fully opaque and enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)