### PR TITLE
Fix contrast on Use Weapon button

### DIFF
--- a/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/CombatChoicePanel.kt
+++ b/app/src/main/java/dev/mattbachmann/scoundroid/ui/component/CombatChoicePanel.kt
@@ -118,6 +118,7 @@ fun CombatChoicePanel(
                         ButtonDefaults.buttonColors(
                             // Blue for weapon
                             containerColor = Color(0xFF1976D2),
+                            contentColor = Color.White,
                         ),
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {


### PR DESCRIPTION
## Summary
- Adds explicit `contentColor = Color.White` to the Use Weapon button in CombatChoicePanel
- Ensures proper text contrast against the blue (`#1976D2`) background
- Previously, Material3's automatic color derivation could result in poor contrast

## Test plan
- [ ] Verify the Use Weapon button text is clearly readable on the blue background
- [ ] Check button appearance in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)