### PR TITLE
Bump version to 1.0.9 for Google Play release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "dev.mattbachmann.scoundroid"
         minSdk = 26
         targetSdk = 36
-        versionCode = 9
-        versionName = "1.0.8"
+        versionCode = 10
+        versionName = "1.0.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- Bumps versionCode from 9 to 10
- Bumps versionName from 1.0.8 to 1.0.9

## Test plan
- [x] Build passes
- [ ] Test on device before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)